### PR TITLE
Add Prisma as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@prisma/client": "3.14.0",
+    "prisma": "3.14.0",
     "blitz": "0.45.4",
     "final-form": "4.20.7",
     "react": "18.0.0",


### PR DESCRIPTION
This PR adds Prisma to the dependencies to fix "Cannot find module 'prisma' error` 