### PR TITLE
Add `email` key to the query string

### DIFF
--- a/app/mutations/addSubscriber.tsx
+++ b/app/mutations/addSubscriber.tsx
@@ -24,7 +24,7 @@ export default async function addSubscriber(input: z.infer<typeof subscriberInfo
       product_name: "PostReview",
       support_email: "hello@postreview.org",
       company_name: "PostReview",
-      unsubscribe_url: `${origin}/unsubscribe?=${subscriber.email}`,
+      unsubscribe_url: `${origin}/unsubscribe?email=${subscriber.email}`,
     },
   }
 


### PR DESCRIPTION
This PR adds the `email` key to the query string to unsubscribe. Fixes #8.