### PR TITLE
Fix the social image by passing a full URL for social image

### DIFF
--- a/app/core/components/SocialMetadata.tsx
+++ b/app/core/components/SocialMetadata.tsx
@@ -4,7 +4,7 @@ export const SocialMetadata = () => {
   const title = "PostReview"
   const description = "Start your new academic year differently with PostReview"
   const rootUrl = new URL("https://www.postreview.org/")
-  const socialImage = "/social-image.jpg"
+  const socialImage = new URL("/social-image.jpg", rootUrl)
   return (
     <>
       <meta name="description" content={title} />
@@ -15,11 +15,11 @@ export const SocialMetadata = () => {
       <meta property="twitter:url" content={rootUrl.href} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      <meta name="twitter:image" content={socialImage} />
+      <meta name="twitter:image" content={socialImage.href} />
       {/* Open Graph */}
       <meta property="og:type" content="website" />
       <meta property="og:url" content={rootUrl.href} key="ogurl" />
-      <meta property="og:image" content={socialImage} key="ogimage" />
+      <meta property="og:image" content={socialImage.href} key="ogimage" />
       <meta property="og:site_name" content={title} key="ogsitename" />
       <meta property="og:title" content={title} key="ogtitle" />
       <meta property="og:description" content={description} key="ogdesc" />

--- a/app/core/components/SocialMetadata.tsx
+++ b/app/core/components/SocialMetadata.tsx
@@ -15,6 +15,8 @@ export const SocialMetadata = () => {
       <meta property="og:site_name" content={title} key="ogsitename" />
       <meta property="og:title" content={title} key="ogtitle" />
       <meta property="og:description" content={description} key="ogdesc" />
+      {/* Twittter */}
+      <meta name="twitter:card" content="summary_large_image" />
     </>
   )
 }

--- a/app/core/components/SocialMetadata.tsx
+++ b/app/core/components/SocialMetadata.tsx
@@ -8,14 +8,6 @@ export const SocialMetadata = () => {
   return (
     <>
       <meta name="description" content={title} />
-
-      {/* Twitter */}
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta property="twitter:domain" content="postreview.org" />
-      <meta property="twitter:url" content={rootUrl.href} />
-      <meta name="twitter:title" content={title} />
-      <meta name="twitter:description" content={description} />
-      <meta name="twitter:image" content={socialImage.href} />
       {/* Open Graph */}
       <meta property="og:type" content="website" />
       <meta property="og:url" content={rootUrl.href} key="ogurl" />


### PR DESCRIPTION
This PR fixes the social image rendering by passing a full URL, instead of a relative one, for the social image. Fixes #20.